### PR TITLE
Fix wriie syscall test failing

### DIFF
--- a/lib/src/c/unistd/syscall.vpr
+++ b/lib/src/c/unistd/syscall.vpr
@@ -8,8 +8,8 @@ namespace std {
         [[NoMangle]] func @syscall5(n: i64, a: i64, b: i64, c: i64, d: i64, e: i64) -> i64;
         [[NoMangle]] func @syscall6(n: i64, a: i64, b: i64, c: i64, d: i64, e: i64, f: i64) -> i64;
 
-        export func @write(fd: i32, data: i8*, count: i32) -> i32 {
-            return (i32)syscall3((i64)1, (i64)fd, (i64)data, (i64)count);
+        export func @write(fd: i64, data: i8*, count: i64) -> i64 {
+            return syscall3((i64)1, fd, (i64)data, count);
         }
 
         export func @mmap(addr: i8*, size: u64, prot: i32, flags: i32, fd: i32, offset: i32) -> i8* {

--- a/tests/src/tests/c/unistd/SyscallTests.cpp
+++ b/tests/src/tests/c/unistd/SyscallTests.cpp
@@ -9,7 +9,7 @@
 
 extern "C"
 {
-    int _F3std1c5writeAibPi(int fd, char* data, int count);
+    int _F3std1c5writeAlbPl(int fd, char* data, int count);
 }
 
 namespace MemoryTests
@@ -19,18 +19,19 @@ namespace MemoryTests
 
     TEST(write, SyscallTests)
     {
-        std::unique_ptr<char[]> data = std::make_unique<char[]>(0x1000);
+        constexpr std::size_t size = 0x1000;
+        std::unique_ptr<char[]> data = std::make_unique<char[]>(size);
         
         random_bytes_engine rbe;
-        std::generate(data.get(), data.get()+0x1000, std::ref(rbe));
+        std::generate(data.get(), data.get() + size, std::ref(rbe));
 
         std::FILE* file = std::tmpfile();
         int fd = fileno(file);
         
-        int count = _F3std1c5writeAibPi(fd, data.get(), 0x1000);
+        int count = _F3std1c5writeAlbPl(fd, data.get(), size);
         rewind(file);
 
-        REQUIRE(count == 0x1000);
+        REQUIRE(count == size);
         for (int i = 0; i < count; ++i)
         {
             REQUIRE((char)getc(file) == data[i]);


### PR DESCRIPTION
Incorrect mapping of int to i32 on x64